### PR TITLE
Refactor compiler and parser modules

### DIFF
--- a/src/compiler/ast.rs
+++ b/src/compiler/ast.rs
@@ -1,8 +1,5 @@
-use super::types::DataType;
-
 /// Abstract Syntax Tree node types representing program structure
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum ASTNode {
     /// Function definition with name, parameters, return type, and body statements
     Function {
@@ -101,7 +98,6 @@ pub enum ASTNode {
 
 /// Match pattern for match statements
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum MatchPattern {
     /// Range pattern (inclusive)
     Range(i32, i32),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,8 +1,8 @@
-use crate::parser::{ASTNode, MatchPattern};
 use crate::errors::{KdnError, KdnResult};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use crate::compiler::ast::{ASTNode, MatchPattern};
 
 /// Optimization levels for the compiler
 #[derive(Debug, Clone, Copy)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,7 @@
-mod ast;
 mod parser;
 mod types;
 
-pub use ast::{ASTNode, MatchPattern};
 pub use parser::KdnParser;
 pub use types::DataType;
+
+use crate::compiler::ast::{ASTNode, MatchPattern};

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,5 +1,6 @@
 use crate::errors::{span, KdnError, KdnResult};
-use crate::parser::{ASTNode, DataType};
+use crate::compiler::ast::{ASTNode, MatchPattern};
+use crate::parser::DataType;
 use miette::NamedSource;
 use pest::Parser;
 use pest_derive::Parser;

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1,4 +1,5 @@
-use crate::parser::{ASTNode, DataType};
+use crate::compiler::ast::{ASTNode, MatchPattern};
+use crate::parser::DataType;
 use crate::errors::{KdnError, KdnResult, span};
 use miette::NamedSource;
 use std::collections::HashMap;


### PR DESCRIPTION
Refactor the compiler and parser to improve maintainability by splitting up the compiler's module files and updating references.

* **Add `src/compiler/ast.rs`**
  - Add `ASTNode` enum definition with variants for different AST nodes.
  - Add `MatchPattern` enum definition for match statement patterns.

* **Modify `src/compiler/mod.rs`**
  - Remove `ASTNode` and `MatchPattern` definitions.
  - Import `ASTNode` and `MatchPattern` from `ast.rs`.

* **Modify `src/parser/mod.rs`**
  - Remove `ASTNode` and `MatchPattern` imports.
  - Import `ASTNode` and `MatchPattern` from `compiler/ast.rs`.

* **Modify `src/parser/parser.rs`**
  - Update `ASTNode` and `MatchPattern` references to use `compiler/ast.rs`.

* **Modify `src/typechecker/mod.rs`**
  - Update `ASTNode` and `MatchPattern` references to use `compiler/ast.rs`.

* **Delete `src/parser/ast.rs`**

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdntNinja/KdnLang/pull/2?shareId=7e29efe1-004b-4000-811f-358b31781a08).